### PR TITLE
flake.nix: Build solc from source using current nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "oldNixpkgs": {
       "locked": {
-        "lastModified": 1646266392,
-        "narHash": "sha256-VharJEJFUt2gWL532j4hdlpQW9ElNXPqDUisIs7XAQw=",
+        "lastModified": 1654862502,
+        "narHash": "sha256-6YyV16ZcPnuCjFgMIsKkEG2fAwwZCx8erkvev5r70cE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d00621a67c271e6adb37bf32b5d8b4ce2010325f",
+        "rev": "80d3c080a94b48edb5c0ab647fde31dd58479905",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "rev": "d00621a67c271e6adb37bf32b5d8b4ce2010325f",
+        "rev": "80d3c080a94b48edb5c0ab647fde31dd58479905",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -38,16 +38,16 @@
     "oldNixpkgs": {
       "flake": false,
       "locked": {
-        "lastModified": 1567802860,
-        "narHash": "sha256-Iy8Rg+6gLe1nrXEF4HkUtGRXJcYBP1r4a2kmXs4Rric=",
+        "lastModified": 1573565576,
+        "narHash": "sha256-TpZPqE559lBUhilh1rse/WgsxRqDxrHpQ8rlnqpLHWg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9894a70299497ee1d2bb746374d986e8d0f771e3",
+        "rev": "d688c7cd05b155e223e478b6e6bda97737d1441b",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "rev": "9894a70299497ee1d2bb746374d986e8d0f771e3",
+        "rev": "d688c7cd05b155e223e478b6e6bda97737d1441b",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,27 @@
         "type": "indirect"
       }
     },
-
+    "oldNixpkgs": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1538837980,
+        "narHash": "sha256-yXabL6neAycf9PQ8L6xR/3nI6xbEwpzyu4/G8wu7dTA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0bcbb978795bab0f1a45accc211b8b0e349f1cdb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "0bcbb978795bab0f1a45accc211b8b0e349f1cdb",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "oldNixpkgs": "oldNixpkgs",
         "systems": "systems"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -38,16 +38,16 @@
     "oldNixpkgs": {
       "flake": false,
       "locked": {
-        "lastModified": 1538837980,
-        "narHash": "sha256-yXabL6neAycf9PQ8L6xR/3nI6xbEwpzyu4/G8wu7dTA=",
+        "lastModified": 1567802860,
+        "narHash": "sha256-Iy8Rg+6gLe1nrXEF4HkUtGRXJcYBP1r4a2kmXs4Rric=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bcbb978795bab0f1a45accc211b8b0e349f1cdb",
+        "rev": "9894a70299497ee1d2bb746374d986e8d0f771e3",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "rev": "0bcbb978795bab0f1a45accc211b8b0e349f1cdb",
+        "rev": "9894a70299497ee1d2bb746374d986e8d0f771e3",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -35,26 +35,10 @@
         "type": "indirect"
       }
     },
-    "oldNixpkgs": {
-      "locked": {
-        "lastModified": 1693985761,
-        "narHash": "sha256-K5b+7j7Tt3+AqbWkcw+wMeqOAWyCD1MH26FPZyWXpdo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
-        "type": "indirect"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "oldNixpkgs": "oldNixpkgs",
         "systems": "systems"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -2,9 +2,7 @@
   "nodes": {
     "flake-utils": {
       "inputs": {
-        "systems": [
-          "systems"
-        ]
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1705309234,
@@ -38,22 +36,21 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "systems": "systems"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
       "locked": {
-        "lastModified": 1680978846,
-        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "x86_64-linux",
-        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "x86_64-linux",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "oldNixpkgs": {
       "locked": {
-        "lastModified": 1613447239,
-        "narHash": "sha256-/Ja3iTaCyU0sgVqnZGJKuARvArOnFRA2gx+A1bJDCD0=",
+        "lastModified": 1640029405,
+        "narHash": "sha256-t04H5W9w77WyruMMz6faNkPJbku8VCh6TY0B/BDPbqg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51d9ad94384f21ecfa17bd9e0b01dfef3d416ab1",
+        "rev": "4adca1dba0d4204bda9e0c4c2e0cc82d31a67f07",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "rev": "51d9ad94384f21ecfa17bd9e0b01dfef3d416ab1",
+        "rev": "4adca1dba0d4204bda9e0c4c2e0cc82d31a67f07",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -36,18 +36,17 @@
       }
     },
     "oldNixpkgs": {
-      "flake": false,
       "locked": {
-        "lastModified": 1573565576,
-        "narHash": "sha256-TpZPqE559lBUhilh1rse/WgsxRqDxrHpQ8rlnqpLHWg=",
+        "lastModified": 1613447239,
+        "narHash": "sha256-/Ja3iTaCyU0sgVqnZGJKuARvArOnFRA2gx+A1bJDCD0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d688c7cd05b155e223e478b6e6bda97737d1441b",
+        "rev": "51d9ad94384f21ecfa17bd9e0b01dfef3d416ab1",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "rev": "d688c7cd05b155e223e478b6e6bda97737d1441b",
+        "rev": "51d9ad94384f21ecfa17bd9e0b01dfef3d416ab1",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "oldNixpkgs": {
       "locked": {
-        "lastModified": 1640029405,
-        "narHash": "sha256-t04H5W9w77WyruMMz6faNkPJbku8VCh6TY0B/BDPbqg=",
+        "lastModified": 1646266392,
+        "narHash": "sha256-VharJEJFUt2gWL532j4hdlpQW9ElNXPqDUisIs7XAQw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4adca1dba0d4204bda9e0c4c2e0cc82d31a67f07",
+        "rev": "d00621a67c271e6adb37bf32b5d8b4ce2010325f",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "rev": "4adca1dba0d4204bda9e0c4c2e0cc82d31a67f07",
+        "rev": "d00621a67c271e6adb37bf32b5d8b4ce2010325f",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "oldNixpkgs": {
       "locked": {
-        "lastModified": 1676298193,
-        "narHash": "sha256-1AyxU60T5ueN1rhJGBNTMZd2lxfIkzrq+piwc/cAg24=",
+        "lastModified": 1693985761,
+        "narHash": "sha256-K5b+7j7Tt3+AqbWkcw+wMeqOAWyCD1MH26FPZyWXpdo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "770cab71da54635e89b587d405f28d87a0fe72bf",
+        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "rev": "770cab71da54635e89b587d405f28d87a0fe72bf",
+        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "oldNixpkgs": {
       "locked": {
-        "lastModified": 1654862502,
-        "narHash": "sha256-6YyV16ZcPnuCjFgMIsKkEG2fAwwZCx8erkvev5r70cE=",
+        "lastModified": 1676298193,
+        "narHash": "sha256-1AyxU60T5ueN1rhJGBNTMZd2lxfIkzrq+piwc/cAg24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "80d3c080a94b48edb5c0ab647fde31dd58479905",
+        "rev": "770cab71da54635e89b587d405f28d87a0fe72bf",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "rev": "80d3c080a94b48edb5c0ab647fde31dd58479905",
+        "rev": "770cab71da54635e89b587d405f28d87a0fe72bf",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   # Old revision of nixos-unstable to get a specific version (0.4.24)
   # of the Solidity compiler, required for building azimuth-solidity.
-  inputs.oldNixpkgs.url = "nixpkgs/770cab71da54635e89b587d405f28d87a0fe72bf";
+  inputs.oldNixpkgs.url = "nixpkgs/0bffda19b8af722f8069d09d8b6a24594c80b352";
 
   # The old revision of nixpkgs needed for solc is broken on many other systems
   inputs.systems.url = "github:nix-systems/x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   # Old revision of nixos-unstable to get a specific version (0.4.24)
   # of the Solidity compiler, required for building azimuth-solidity.
-  inputs.oldNixpkgs.url = "nixpkgs/9894a70299497ee1d2bb746374d986e8d0f771e3";
+  inputs.oldNixpkgs.url = "nixpkgs/d688c7cd05b155e223e478b6e6bda97737d1441b";
   inputs.oldNixpkgs.flake = false;  # The revision is so old that the repo does not contain a flake.nix
 
   # The old revision of nixpkgs needed for solc is broken on many other systems

--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,7 @@
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  # The old revision of nixpkgs needed for solc is broken on many other systems
-  inputs.systems.url = "github:nix-systems/x86_64-linux";
-  inputs.flake-utils.inputs.systems.follows = "systems";
-
-  outputs = { self, nixpkgs, flake-utils, systems }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   # Old revision of nixos-unstable to get a specific version (0.4.24)
   # of the Solidity compiler, required for building azimuth-solidity.
-  inputs.oldNixpkgs.url = "nixpkgs/80d3c080a94b48edb5c0ab647fde31dd58479905";
+  inputs.oldNixpkgs.url = "nixpkgs/770cab71da54635e89b587d405f28d87a0fe72bf";
 
   # The old revision of nixpkgs needed for solc is broken on many other systems
   inputs.systems.url = "github:nix-systems/x86_64-linux";
@@ -19,7 +19,9 @@
         oldPkgs = import oldNixpkgs { inherit system; };
         node2nixOutput = import ./default.nix { inherit pkgs system; };
 
-        solc_0_4_24 = oldPkgs.callPackage ./solc_0_4_24 { };
+        solc_0_4_24 = oldPkgs.callPackage ./solc_0_4_24 {
+          boost = oldPkgs.boost177;
+        };
 
         node2nixOutputOverride = builtins.mapAttrs (name: value: value.override {
           buildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   # Old revision of nixos-unstable to get a specific version (0.4.24)
   # of the Solidity compiler, required for building azimuth-solidity.
-  inputs.oldNixpkgs.url = "nixpkgs/51d9ad94384f21ecfa17bd9e0b01dfef3d416ab1";
+  inputs.oldNixpkgs.url = "nixpkgs/4adca1dba0d4204bda9e0c4c2e0cc82d31a67f07";
 
   # The old revision of nixpkgs needed for solc is broken on many other systems
   inputs.systems.url = "github:nix-systems/x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   # Old revision of nixos-unstable to get a specific version (0.4.24)
   # of the Solidity compiler, required for building azimuth-solidity.
-  inputs.oldNixpkgs.url = "nixpkgs/0bcbb978795bab0f1a45accc211b8b0e349f1cdb";
+  inputs.oldNixpkgs.url = "nixpkgs/9894a70299497ee1d2bb746374d986e8d0f771e3";
   inputs.oldNixpkgs.flake = false;  # The revision is so old that the repo does not contain a flake.nix
 
   # The old revision of nixpkgs needed for solc is broken on many other systems

--- a/flake.nix
+++ b/flake.nix
@@ -6,8 +6,7 @@
 
   # Old revision of nixos-unstable to get a specific version (0.4.24)
   # of the Solidity compiler, required for building azimuth-solidity.
-  inputs.oldNixpkgs.url = "nixpkgs/d688c7cd05b155e223e478b6e6bda97737d1441b";
-  inputs.oldNixpkgs.flake = false;  # The revision is so old that the repo does not contain a flake.nix
+  inputs.oldNixpkgs.url = "nixpkgs/51d9ad94384f21ecfa17bd9e0b01dfef3d416ab1";
 
   # The old revision of nixpkgs needed for solc is broken on many other systems
   inputs.systems.url = "github:nix-systems/x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   # Old revision of nixos-unstable to get a specific version (0.4.24)
   # of the Solidity compiler, required for building azimuth-solidity.
-  inputs.oldNixpkgs.url = "nixpkgs/d00621a67c271e6adb37bf32b5d8b4ce2010325f";
+  inputs.oldNixpkgs.url = "nixpkgs/80d3c080a94b48edb5c0ab647fde31dd58479905";
 
   # The old revision of nixpkgs needed for solc is broken on many other systems
   inputs.systems.url = "github:nix-systems/x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,12 @@
         oldPkgs = import oldNixpkgs { inherit system; };
         node2nixOutput = import ./default.nix { inherit pkgs system; };
 
+        solc_0_4_24 = oldPkgs.callPackage ./solc_0_4_24 { };
+
         node2nixOutputOverride = builtins.mapAttrs (name: value: value.override {
           buildInputs = [
             pkgs.nodePackages.node-gyp-build
-            oldPkgs.solc
+            solc_0_4_24
           ];
           preRebuild = ''
             ## Fix paths in shebang lines ##

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   # Old revision of nixos-unstable to get a specific version (0.4.24)
   # of the Solidity compiler, required for building azimuth-solidity.
-  inputs.oldNixpkgs.url = "nixpkgs/4adca1dba0d4204bda9e0c4c2e0cc82d31a67f07";
+  inputs.oldNixpkgs.url = "nixpkgs/d00621a67c271e6adb37bf32b5d8b4ce2010325f";
 
   # The old revision of nixpkgs needed for solc is broken on many other systems
   inputs.systems.url = "github:nix-systems/x86_64-linux";

--- a/solc_0_4_24/default.nix
+++ b/solc_0_4_24/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchzip, fetchFromGitHub, boost, cmake, z3 }:
+
+let
+  version = "0.4.24";
+  rev = "e67f0147998a9e3835ed3ce8bf6a0a0c634216c5";
+  sha256 = "1gy2miv6ia1z98zy6w4y03balwfr964bnvwzyg8v7pn2mayqnaap";
+  jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
+  jsoncpp = fetchzip {
+    url = jsoncppURL;
+    sha256 = "1z0gj7a6jypkijmpknis04qybs1hkd04d1arr3gy89lnxmp6qzlm";
+  };
+in
+stdenv.mkDerivation {
+  name = "solc-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "solidity";
+    inherit rev sha256;
+  };
+
+  patches = [
+    ./patches/shared-libs-install.patch
+  ];
+
+  postPatch = ''
+    touch prerelease.txt
+    echo >commit_hash.txt "${rev}"
+    substituteInPlace cmake/jsoncpp.cmake \
+      --replace "${jsoncppURL}" ${jsoncpp}
+
+    # To allow non-standard CMAKE_INSTALL_LIBDIR (fixed in upstream, not yet released)
+    substituteInPlace cmake/jsoncpp.cmake \
+      --replace "\''${CMAKE_INSTALL_LIBDIR}" "lib" \
+      --replace "# Build static lib but suitable to be included in a shared lib." "-DCMAKE_INSTALL_LIBDIR=lib"
+  '';
+
+  cmakeFlags = [
+    "-DBoost_USE_STATIC_LIBS=OFF"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DINSTALL_LLLC=ON"
+  ];
+
+  doCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform;
+  checkPhase = "LD_LIBRARY_PATH=./libsolc:./libsolidity:./liblll:./libevmasm:./libdevcore:$LD_LIBRARY_PATH " +
+               "./test/soltest -p -- --no-ipc --no-smt --testpath ../test";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost z3 ];
+
+  outputs = [ "out" "dev" ];
+
+  meta = with stdenv.lib; {
+    description = "Compiler for Ethereum smart contract language Solidity";
+    longDescription = "This package also includes `lllc', the LLL compiler.";
+    homepage = https://github.com/ethereum/solidity;
+    license = licenses.gpl3;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ dbrock akru ];
+    inherit version;
+  };
+}

--- a/solc_0_4_24/default.nix
+++ b/solc_0_4_24/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./patches/shared-libs-install.patch
+    ./patches/gcc8.patch
   ];
 
   postPatch = ''

--- a/solc_0_4_24/default.nix
+++ b/solc_0_4_24/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
   patches = [
     ./patches/shared-libs-install.patch
     ./patches/gcc8.patch
+    ./patches/gcc11.patch
     ./patches/boost169.patch
     ./patches/boost177.patch
   ];

--- a/solc_0_4_24/default.nix
+++ b/solc_0_4_24/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
     ./patches/shared-libs-install.patch
     ./patches/gcc8.patch
     ./patches/boost169.patch
+    ./patches/boost177.patch
   ];
 
   postPatch = ''

--- a/solc_0_4_24/default.nix
+++ b/solc_0_4_24/default.nix
@@ -4,10 +4,10 @@ let
   version = "0.4.24";
   rev = "e67f0147998a9e3835ed3ce8bf6a0a0c634216c5";
   sha256 = "1gy2miv6ia1z98zy6w4y03balwfr964bnvwzyg8v7pn2mayqnaap";
-  jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
+  jsoncppURL = "https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz";
   jsoncpp = fetchzip {
     url = jsoncppURL;
-    sha256 = "1z0gj7a6jypkijmpknis04qybs1hkd04d1arr3gy89lnxmp6qzlm";
+    hash = "sha256-mBLBwuIYPonclPyEdFywi7W70WpOqnKEy4q/PECJcO0=";
   };
 in
 stdenv.mkDerivation {
@@ -26,18 +26,13 @@ stdenv.mkDerivation {
     ./patches/boost169.patch
     ./patches/boost177.patch
     ./patches/disable-Werror.patch
+    ./patches/jsoncpp-macos.patch
   ];
 
   postPatch = ''
     touch prerelease.txt
     echo >commit_hash.txt "${rev}"
-    substituteInPlace cmake/jsoncpp.cmake \
-      --replace "${jsoncppURL}" ${jsoncpp}
-
-    # To allow non-standard CMAKE_INSTALL_LIBDIR (fixed in upstream, not yet released)
-    substituteInPlace cmake/jsoncpp.cmake \
-      --replace "\''${CMAKE_INSTALL_LIBDIR}" "lib" \
-      --replace "# Build static lib but suitable to be included in a shared lib." "-DCMAKE_INSTALL_LIBDIR=lib"
+    substituteInPlace cmake/jsoncpp.cmake --replace "${jsoncppURL}" ${jsoncpp}
   '';
 
   cmakeFlags = [

--- a/solc_0_4_24/default.nix
+++ b/solc_0_4_24/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
     ./patches/gcc11.patch
     ./patches/boost169.patch
     ./patches/boost177.patch
+    ./patches/disable-Werror.patch
   ];
 
   postPatch = ''

--- a/solc_0_4_24/default.nix
+++ b/solc_0_4_24/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
   patches = [
     ./patches/shared-libs-install.patch
     ./patches/gcc8.patch
+    ./patches/boost169.patch
   ];
 
   postPatch = ''
@@ -44,7 +45,7 @@ stdenv.mkDerivation {
 
   doCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform;
   checkPhase = "LD_LIBRARY_PATH=./libsolc:./libsolidity:./liblll:./libevmasm:./libdevcore:$LD_LIBRARY_PATH " +
-               "./test/soltest -p -- --no-ipc --no-smt --testpath ../test";
+               "./test/soltest --show-progress=true -- --no-ipc --no-smt --testpath ../test";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost z3 ];

--- a/solc_0_4_24/default.nix
+++ b/solc_0_4_24/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, fetchFromGitHub, boost, cmake, z3 }:
+{ stdenv, lib, fetchzip, fetchFromGitHub, boost, cmake, z3 }:
 
 let
   version = "0.4.24";
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Compiler for Ethereum smart contract language Solidity";
     longDescription = "This package also includes `lllc', the LLL compiler.";
     homepage = https://github.com/ethereum/solidity;

--- a/solc_0_4_24/patches/boost169.patch
+++ b/solc_0_4_24/patches/boost169.patch
@@ -1,0 +1,69 @@
+commit d3c3fd20796dd18b7213938bd0ce89e8aeb9d6f3
+Author: Alex Beregszaszi <alex@rtfs.hu>
+Date:   Wed Aug 8 20:46:28 2018 +0100
+
+    Use dev::toString() in Assembly instead of misusing string{} for u256
+
+diff --git a/libevmasm/Assembly.cpp b/libevmasm/Assembly.cpp
+index b71bc80cb..28ae95777 100644
+--- a/libevmasm/Assembly.cpp
++++ b/libevmasm/Assembly.cpp
+@@ -264,7 +264,7 @@ Json::Value Assembly::assemblyJSON(StringMap const& _sourceCodes) const
+ 					createJsonValue("PUSH [ErrorTag]", i.location().start, i.location().end, ""));
+ 			else
+ 				collection.append(
+-					createJsonValue("PUSH [tag]", i.location().start, i.location().end, string(i.data())));
++					createJsonValue("PUSH [tag]", i.location().start, i.location().end, dev::toString(i.data())));
+ 			break;
+ 		case PushSub:
+ 			collection.append(
+@@ -290,7 +290,7 @@ Json::Value Assembly::assemblyJSON(StringMap const& _sourceCodes) const
+ 			break;
+ 		case Tag:
+ 			collection.append(
+-				createJsonValue("tag", i.location().start, i.location().end, string(i.data())));
++				createJsonValue("tag", i.location().start, i.location().end, dev::toString(i.data())));
+ 			collection.append(
+ 				createJsonValue("JUMPDEST", i.location().start, i.location().end));
+ 			break;
+
+commit 55d91d5f9cdc176c771b6038948d5dacba383e34
+Author: Bhargava Shastry <bshastry@sect.tu-berlin.de>
+Date:   Mon Oct 15 17:14:22 2018 +0200
+
+    Bug fix: Add missing include in test/Options.h; otherwise compiler does not recognise the boost object that Options subclasses
+
+diff --git a/test/Options.h b/test/Options.h
+index 9bc698762..cbaa0dd1a 100644
+--- a/test/Options.h
++++ b/test/Options.h
+@@ -24,7 +24,7 @@
+ #include <boost/test/unit_test.hpp>
+ #include <boost/filesystem.hpp>
+ #include <boost/version.hpp>
+-
++#include <boost/core/noncopyable.hpp>
+ #include <functional>
+ 
+ namespace dev
+
+commit 3d4e5f30e1696bee8482058b5ec4adb51f9f1387
+Author: chriseth <chris@ethereum.org>
+Date:   Mon Oct 15 18:08:41 2018 +0200
+
+    Correct include path
+
+diff --git a/test/Options.h b/test/Options.h
+index cbaa0dd1a..0e8a51dad 100644
+--- a/test/Options.h
++++ b/test/Options.h
+@@ -24,7 +24,8 @@
+ #include <boost/test/unit_test.hpp>
+ #include <boost/filesystem.hpp>
+ #include <boost/version.hpp>
+-#include <boost/core/noncopyable.hpp>
++#include <boost/noncopyable.hpp>
++
+ #include <functional>
+ 
+ namespace dev

--- a/solc_0_4_24/patches/boost177.patch
+++ b/solc_0_4_24/patches/boost177.patch
@@ -1,0 +1,32 @@
+commit 3abd5f64bdddec17d6ead9233f9a1e4a5d7a56ab
+Author: Chris Kerr <ckerr@chorus.one>
+Date:   Tue Feb 20 16:38:18 2024 +0200
+
+    Patch LLL parser for Boost 1.77
+    
+    The LLL parser was deleted upstream before the Boost changes, so there
+    are no patches for this build error in the upstream repo.
+
+diff --git a/liblll/Parser.cpp b/liblll/Parser.cpp
+index a3962df46..49542deb6 100644
+--- a/liblll/Parser.cpp
++++ b/liblll/Parser.cpp
+@@ -30,6 +30,7 @@
+ #include <boost/spirit/include/qi.hpp>
+ #include <boost/spirit/include/phoenix.hpp>
+ #include <boost/spirit/include/support_utree.hpp>
++#include <boost/spirit/include/support_string_traits.hpp>
+ 
+ using namespace std;
+ using namespace dev;
+@@ -67,8 +68,8 @@ void dev::eth::debugOutAST(ostream& _out, sp::utree const& _this)
+ 
+ 		break;
+ 	case sp::utree_type::int_type: _out << _this.get<int>(); break;
+-	case sp::utree_type::string_type: _out << "\"" << _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>() << "\""; break;
+-	case sp::utree_type::symbol_type: _out << _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::symbol_type>>(); break;
++	case sp::utree_type::string_type: _out << "\"" << sp::traits::get_c_string(_this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>()) << "\""; break;
++	case sp::utree_type::symbol_type: _out << sp::traits::get_c_string(_this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::symbol_type>>()); break;
+ 	case sp::utree_type::any_type: _out << *_this.get<bigint*>(); break;
+ 	default: _out << "nil";
+ 	}

--- a/solc_0_4_24/patches/disable-Werror.patch
+++ b/solc_0_4_24/patches/disable-Werror.patch
@@ -1,0 +1,18 @@
+commit 4de717637ce21e647cbbb5dffc6c8e82a857232f
+Author: Chris Kerr <ckerr@chorus.one>
+Date:   Wed Feb 21 11:39:48 2024 +0200
+
+    Disable -Werror
+
+diff --git a/cmake/EthCompilerSettings.cmake b/cmake/EthCompilerSettings.cmake
+index 683d1d2e6..cf57ee3dc 100644
+--- a/cmake/EthCompilerSettings.cmake
++++ b/cmake/EthCompilerSettings.cmake
+@@ -34,7 +34,6 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
+ 	# to fix warnings as they arise, so they don't accumulate "to be fixed later".
+ 	add_compile_options(-Wall)
+ 	add_compile_options(-Wextra)
+-	add_compile_options(-Werror)
+ 
+ 	# Disable warnings about unknown pragmas (which is enabled by -Wall).  I assume we have external
+ 	# dependencies (probably Boost) which have some of these.   Whatever the case, we shouldn't be

--- a/solc_0_4_24/patches/gcc11.patch
+++ b/solc_0_4_24/patches/gcc11.patch
@@ -1,0 +1,121 @@
+commit 0480ca819c7df756c4f25131881662544f317590
+Author: Chris Kerr <ckerr@chorus.one>
+Date:   Tue Feb 20 18:35:06 2024 +0200
+
+    Compatibility with GCC 11
+    
+    Use a const reference for the loop variable
+    
+    This change is taken from upstream cae6e7769f3e3b804228061c87bdcaac20a0324e
+    from PR https://github.com/ethereum/solidity/pull/8568 but that commit
+    also changes several other parts of the code so I am isolating this change.
+
+diff --git a/libjulia/optimiser/NameCollector.cpp b/libjulia/optimiser/NameCollector.cpp
+index c0d0b7077..d9aebdd66 100644
+--- a/libjulia/optimiser/NameCollector.cpp
++++ b/libjulia/optimiser/NameCollector.cpp
+@@ -35,9 +35,9 @@ void NameCollector::operator()(VariableDeclaration const& _varDecl)
+ void NameCollector::operator ()(FunctionDefinition const& _funDef)
+ {
+ 	m_names.insert(_funDef.name);
+-	for (auto const arg: _funDef.parameters)
++	for (auto const& arg: _funDef.parameters)
+ 		m_names.insert(arg.name);
+-	for (auto const ret: _funDef.returnVariables)
++	for (auto const& ret: _funDef.returnVariables)
+ 		m_names.insert(ret.name);
+ 	ASTWalker::operator ()(_funDef);
+ }
+
+commit b77a8e849fc7a376fc414931363426836f265ecc
+Author: Mathias Baumann <marenz@supradigital.org>
+Date:   Mon May 11 14:59:06 2020 +0200
+
+    Fix clang v10 compilation errors
+    
+    (cherry picked from commit fe431320033d341c782297f38e5e1fb42c791ead)
+    
+    Extended the same changes to cover test/libsolidity/SolidityExpressionCompiler.cpp
+    where the failing line had been removed upstream before the
+    cherry-picked commit.
+
+diff --git a/libsolidity/analysis/GlobalContext.cpp b/libsolidity/analysis/GlobalContext.cpp
+index 756bb540a..dd01bfc60 100644
+--- a/libsolidity/analysis/GlobalContext.cpp
++++ b/libsolidity/analysis/GlobalContext.cpp
+@@ -74,7 +74,7 @@ vector<Declaration const*> GlobalContext::declarations() const
+ {
+ 	vector<Declaration const*> declarations;
+ 	declarations.reserve(m_magicVariables.size());
+-	for (ASTPointer<Declaration const> const& variable: m_magicVariables)
++	for (ASTPointer<MagicVariableDeclaration const> const& variable: m_magicVariables)
+ 		declarations.push_back(variable.get());
+ 	return declarations;
+ }
+diff --git a/libsolidity/codegen/ContractCompiler.cpp b/libsolidity/codegen/ContractCompiler.cpp
+index 0889ac7ce..24580ac37 100644
+--- a/libsolidity/codegen/ContractCompiler.cpp
++++ b/libsolidity/codegen/ContractCompiler.cpp
+@@ -433,13 +433,13 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
+ 	if (!_function.isConstructor())
+ 		// adding 1 for return address.
+ 		m_context.adjustStackOffset(parametersSize + 1);
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.parameters())
++	for (ASTPointer<VariableDeclaration> const& variable: _function.parameters())
+ 	{
+ 		m_context.addVariable(*variable, parametersSize);
+ 		parametersSize -= variable->annotation().type->sizeOnStack();
+ 	}
+ 
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.returnParameters())
++	for (ASTPointer<VariableDeclaration> const& variable: _function.returnParameters())
+ 		appendStackVariableInitialisation(*variable);
+ 	for (VariableDeclaration const* localVariable: _function.localVariables())
+ 		appendStackVariableInitialisation(*localVariable);
+@@ -495,7 +495,7 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
+ 		}
+ 	//@todo assert that everything is in place now
+ 
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.parameters() + _function.returnParameters())
++	for (ASTPointer<VariableDeclaration> const& variable: _function.parameters() + _function.returnParameters())
+ 		m_context.removeVariable(*variable);
+ 	for (VariableDeclaration const* localVariable: _function.localVariables())
+ 		m_context.removeVariable(*localVariable);
+diff --git a/test/libsolidity/SolidityExpressionCompiler.cpp b/test/libsolidity/SolidityExpressionCompiler.cpp
+index 90d8265c6..59ac16284 100644
+--- a/test/libsolidity/SolidityExpressionCompiler.cpp
++++ b/test/libsolidity/SolidityExpressionCompiler.cpp
+@@ -112,7 +112,7 @@ bytes compileFirstExpression(
+ 
+ 	vector<Declaration const*> declarations;
+ 	declarations.reserve(_globalDeclarations.size() + 1);
+-	for (ASTPointer<Declaration const> const& variable: _globalDeclarations)
++	for (ASTPointer<MagicVariableDeclaration const> const& variable: _globalDeclarations)
+ 		declarations.push_back(variable.get());
+ 
+ 	ErrorList errors;
+
+commit 94c898602ab0910be7690bc6b0e988a038ea1aa1
+Author: Peter Lemenkov <lemenkov@gmail.com>
+Date:   Fri Jul 1 12:09:08 2022 +0200
+
+    Initialize vars before use
+    
+    Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>
+    (cherry picked from commit 93c8120a249a7359f861618593d83310ae2d268b)
+
+diff --git a/libsolidity/parsing/Scanner.cpp b/libsolidity/parsing/Scanner.cpp
+index 6541f6c2f..7970c34e1 100644
+--- a/libsolidity/parsing/Scanner.cpp
++++ b/libsolidity/parsing/Scanner.cpp
+@@ -427,8 +427,8 @@ void Scanner::scanToken()
+ 
+ 	Token::Value token;
+ 	// M and N are for the purposes of grabbing different type sizes
+-	unsigned m;
+-	unsigned n;
++	unsigned m = 0;
++	unsigned n = 0;
+ 	do
+ 	{
+ 		// Remember the position of the next token

--- a/solc_0_4_24/patches/gcc8.patch
+++ b/solc_0_4_24/patches/gcc8.patch
@@ -1,0 +1,50 @@
+commit 9e26f5fa0a956543f14dd84eb9d461ca75cce95e
+Author: Julius Huelsmann <huelsmann@campus.tu-berlin.de>
+Date:   Thu May 17 12:16:28 2018 +0200
+
+    Do not catch exceptions by value in StandardCompiler
+
+diff --git a/libsolidity/interface/StandardCompiler.cpp b/libsolidity/interface/StandardCompiler.cpp
+index ee9b14406..c8d43e9f6 100644
+--- a/libsolidity/interface/StandardCompiler.cpp
++++ b/libsolidity/interface/StandardCompiler.cpp
+@@ -117,7 +117,7 @@ bool hashMatchesContent(string const& _hash, string const& _content)
+ 	{
+ 		return dev::h256(_hash) == dev::keccak256(_content);
+ 	}
+-	catch (dev::BadHexCharacter)
++	catch (dev::BadHexCharacter const&)
+ 	{
+ 		return false;
+ 	}
+@@ -366,7 +366,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
+ 				// @TODO use libraries only for the given source
+ 				libraries[library] = h160(address);
+ 			}
+-			catch (dev::BadHexCharacter)
++			catch (dev::BadHexCharacter const&)
+ 			{
+ 				return formatFatalError(
+ 					"JSONError",
+
+commit 1d3a37faff9a82a5269c3414a2d6fe868593afb1
+Author: Julius Huelsmann <huelsmann@campus.tu-berlin.de>
+Date:   Thu May 17 12:19:29 2018 +0200
+
+    Avoid "unneccesary parentheses in declaration of" warning with keeping a temporary variable.
+
+diff --git a/libsolidity/inlineasm/AsmParser.cpp b/libsolidity/inlineasm/AsmParser.cpp
+index d3b0808b4..d300f8fba 100644
+--- a/libsolidity/inlineasm/AsmParser.cpp
++++ b/libsolidity/inlineasm/AsmParser.cpp
+@@ -606,7 +606,9 @@ bool Parser::isValidNumberLiteral(string const& _literal)
+ {
+ 	try
+ 	{
+-		u256(_literal);
++		// Try to convert _literal to u256.
++		auto tmp = u256(_literal);
++		(void) tmp;
+ 	}
+ 	catch (...)
+ 	{

--- a/solc_0_4_24/patches/jsoncpp-macos.patch
+++ b/solc_0_4_24/patches/jsoncpp-macos.patch
@@ -1,0 +1,372 @@
+commit 7db058074b97bdc6a36e372f8708d3adee62991c
+Author: Paweł Bylica <chfast@gmail.com>
+Date:   Thu May 17 14:42:22 2018 +0200
+
+    CMake: Fix libdir for jsoncpp external project in special case
+    
+    When building on Debian/Ubuntu with install prefix /usr (e.g. in PPA builds) the CMAKE_INSTALL_LIBDIR is resolved to lib/x86_64-linux-gnu. For jsoncpp external project this is never the case because the install prefix is not /usr. Remove multiarch part from libdir if there.
+
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index 3d6b37edf..cc2da7e7e 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -7,8 +7,14 @@ else()
+ endif()
+ 
+ include(GNUInstallDirs)
++set(libdir ${CMAKE_INSTALL_LIBDIR})
++if(CMAKE_LIBRARY_ARCHITECTURE)
++    # Do not use Debian multiarch library dir.
++    string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" libdir ${libdir})
++endif()
++
+ set(prefix "${CMAKE_BINARY_DIR}/deps")
+-set(JSONCPP_LIBRARY "${prefix}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
++set(JSONCPP_LIBRARY "${prefix}/${libdir}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
+ set(JSONCPP_INCLUDE_DIR "${prefix}/include")
+ 
+ if(NOT MSVC)
+commit a104e5fb03650042ba106c7334c02cbe0110bd91
+Author: mingchuan <mingc@skymizer.com>
+Date:   Wed Jun 6 14:03:07 2018 +0800
+
+    Fix cmake when custom CMAKE_INSTALL_LIBDIR is given
+    
+    According to cmake documents, we cannot assume CMAKE_INSTALL_LIBDIR is a
+    relative path. This commit fixes the "no rule to make libjsoncpp.a"
+    error by passing -DCMAKE_INSTALL_LIBDIR=lib to jsoncpp external project.
+
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index cc2da7e7e..0c110b532 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -6,15 +6,8 @@ else()
+     set(JSONCPP_CMAKE_COMMAND ${CMAKE_COMMAND})
+ endif()
+ 
+-include(GNUInstallDirs)
+-set(libdir ${CMAKE_INSTALL_LIBDIR})
+-if(CMAKE_LIBRARY_ARCHITECTURE)
+-    # Do not use Debian multiarch library dir.
+-    string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" libdir ${libdir})
+-endif()
+-
+ set(prefix "${CMAKE_BINARY_DIR}/deps")
+-set(JSONCPP_LIBRARY "${prefix}/${libdir}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
++set(JSONCPP_LIBRARY "${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
+ set(JSONCPP_INCLUDE_DIR "${prefix}/include")
+ 
+ if(NOT MSVC)
+@@ -36,6 +29,7 @@ ExternalProject_Add(jsoncpp-project
+     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
++               -DCMAKE_INSTALL_LIBDIR=lib
+                # Build static lib but suitable to be included in a shared lib.
+                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+                -DJSONCPP_WITH_TESTS=OFF
+commit 230317e9ff97ba3b110a95bd22c2656b42fc70b6
+Author: Christian Parpart <christian@parpart.family>
+Date:   Tue Jul 10 15:12:32 2018 +0200
+
+    Visual Studio 2017 build-time (linking) fix and improvements
+
+diff --git a/.gitignore b/.gitignore
+index 14c227d05..87a3e5933 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -35,6 +35,7 @@ build/
+ docs/_build
+ docs/utils/__pycache__
+ docs/utils/*.pyc
++/deps/downloads/
+ 
+ # vim stuff
+ *.swp
+@@ -43,3 +44,5 @@ docs/utils/*.pyc
+ .idea
+ browse.VC.db
+ CMakeLists.txt.user
++/CMakeSettings.json
++/.vs
+diff --git a/cmake/EthCompilerSettings.cmake b/cmake/EthCompilerSettings.cmake
+index 683d1d2e6..3ae5bf2ab 100644
+--- a/cmake/EthCompilerSettings.cmake
++++ b/cmake/EthCompilerSettings.cmake
+@@ -132,17 +132,6 @@ elseif (DEFINED MSVC)
+ 	add_compile_options(-D_WIN32_WINNT=0x0600)		# declare Windows Vista API requirement
+ 	add_compile_options(-DNOMINMAX)					# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
+ 
+-	# Always use Release variant of C++ runtime.
+-	# We don't want to provide Debug variants of all dependencies. Some default
+-	# flags set by CMake must be tweaked.
+-	string(REPLACE "/MDd" "/MD" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+-	string(REPLACE "/D_DEBUG" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+-	string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+-	string(REPLACE "/MDd" "/MD" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+-	string(REPLACE "/D_DEBUG" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+-	string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+-	set_property(GLOBAL PROPERTY DEBUG_CONFIGURATIONS OFF)
+-
+ 	# disable empty object file warning
+ 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
+ 	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index 0c110b532..e886c6092 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -35,9 +35,7 @@ ExternalProject_Add(jsoncpp-project
+                -DJSONCPP_WITH_TESTS=OFF
+                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
+                -DCMAKE_CXX_FLAGS=${JSONCPP_EXTRA_FLAGS}
+-    # Overwrite build and install commands to force Release build on MSVC.
+-    BUILD_COMMAND cmake --build <BINARY_DIR> --config Release
+-    INSTALL_COMMAND cmake --build <BINARY_DIR> --config Release --target install
++               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+     ${byproducts}
+ )
+ 
+commit 096cac5e6538bb85c3c51fca013ef4bb2cbcf974
+Author: Guido Vranken <guidovranken@gmail.com>
+Date:   Thu Jul 19 00:05:45 2018 +0200
+
+    Propagate original CMAKE_CXX_FLAGS to jsoncpp compilation
+
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index e886c6092..a6ca0e7fa 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -34,7 +34,7 @@ ExternalProject_Add(jsoncpp-project
+                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+                -DJSONCPP_WITH_TESTS=OFF
+                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
+-               -DCMAKE_CXX_FLAGS=${JSONCPP_EXTRA_FLAGS}
++               -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${JSONCPP_EXTRA_FLAGS}
+                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+     ${byproducts}
+ )
+commit fb0e3b25d00320fd49817ff807a9bfaf1fe16062
+Author: Daniel Kirchner <daniel@ekpyron.org>
+Date:   Fri Aug 3 16:50:08 2018 +0200
+
+    Rename JSONCPP_EXTRA_FLAGS to JSONCPP_CXX_FLAGS, add EMSCRIPTEN workaround and remove obsolete MSVC workaround.
+
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index a6ca0e7fa..ea3218efc 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -10,8 +10,16 @@ set(prefix "${CMAKE_BINARY_DIR}/deps")
+ set(JSONCPP_LIBRARY "${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
+ set(JSONCPP_INCLUDE_DIR "${prefix}/include")
+ 
+-if(NOT MSVC)
+-    set(JSONCPP_EXTRA_FLAGS "-std=c++11")
++# TODO: Investigate why this breaks some emscripten builds and
++# check whether this can be removed after updating the emscripten
++# versions used in the CI runs.
++if(EMSCRIPTEN)
++    # Do not include all flags in CMAKE_CXX_FLAGS for emscripten,
++    # but only use -std=c++11. Using all flags causes build failures
++    # at the moment.
++    set(JSONCPP_CXX_FLAGS -std=c++11)
++else()
++    set(JSONCPP_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+ endif()
+ 
+ set(byproducts "")
+@@ -34,7 +42,7 @@ ExternalProject_Add(jsoncpp-project
+                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+                -DJSONCPP_WITH_TESTS=OFF
+                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
+-               -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${JSONCPP_EXTRA_FLAGS}
++               -DCMAKE_CXX_FLAGS=${JSONCPP_CXX_FLAGS}
+                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+     ${byproducts}
+ )
+commit 4c382609cc34c54cac8ca85361d94574619899c9
+Author: Christian Parpart <christian@ethereum.org>
+Date:   Wed Dec 19 17:28:05 2018 +0100
+
+    cmake: Do not depend on a C compiler to be present by explicitly stating that this is a C++ project.
+    
+    CMake defaults to C *and* C++ toolchain, in case nothing has been specified.
+    This means that cmake always checks for both, which is more than needed.
+    
+    This PR cuts off C toolchain requirement from /CMakeLists.txt and ensures that we
+    don't pass along any `..._C_...` variables in EthCompilerSettings.cake nor jsoncpp.cmake.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8893648e4..783530352 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,7 +9,7 @@ eth_policy()
+ 
+ # project name and version should be set after cmake_policy CMP0048
+ set(PROJECT_VERSION "0.4.24")
+-project(solidity VERSION ${PROJECT_VERSION})
++project(solidity VERSION ${PROJECT_VERSION} LANGUAGES CXX)
+ 
+ option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms" OFF)
+ option(LLLC_LINK_STATIC "Link lllc executable statically on supported platforms" OFF)
+diff --git a/cmake/EthCompilerSettings.cmake b/cmake/EthCompilerSettings.cmake
+index 518a70de2..9ed5bf75b 100644
+--- a/cmake/EthCompilerSettings.cmake
++++ b/cmake/EthCompilerSettings.cmake
+@@ -169,9 +169,8 @@ endif ()
+ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
+ 	option(USE_LD_GOLD "Use GNU gold linker" ON)
+ 	if (USE_LD_GOLD)
+-		execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
++		execute_process(COMMAND ${CMAKE_CXX_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+ 		if ("${LD_VERSION}" MATCHES "GNU gold")
+-			set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
+ 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
+ 		endif ()
+ 	endif ()
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index ea3218efc..4b796d71b 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -35,7 +35,6 @@ ExternalProject_Add(jsoncpp-project
+     URL_HASH SHA256=c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6
+     CMAKE_COMMAND ${JSONCPP_CMAKE_COMMAND}
+     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+-               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                -DCMAKE_INSTALL_LIBDIR=lib
+                # Build static lib but suitable to be included in a shared lib.
+commit ffbf7e6c7aa47a6f03a2df69838fd4d87511fd91
+Author: Bhargava Shastry <bhargava.shastry@ethereum.org>
+Date:   Thu Aug 15 15:41:40 2019 +0200
+
+    jsoncpp: force explicit casts for integer to floating point conversions
+
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index 48cec7318..3e72a8be2 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -19,7 +19,14 @@ if(EMSCRIPTEN)
+     # at the moment.
+     set(JSONCPP_CXX_FLAGS -std=c++17)
+ else()
+-    set(JSONCPP_CXX_FLAGS ${CMAKE_CXX_FLAGS})
++    # jsoncpp uses implicit casts for comparing integer and
++    # floating point numbers. This causes clang-10 (used by ossfuzz builder)
++    # to error on the implicit conversions. Here, we request jsoncpp
++    # to unconditionally use static casts for these conversions by defining the
++    # JSON_USE_INT64_DOUBLE_CONVERSION preprocessor macro. Doing so,
++    # not only gets rid of the implicit conversion error that clang-10 produces
++    # but also forces safer behavior in general.
++    set(JSONCPP_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJSON_USE_INT64_DOUBLE_CONVERSION")
+ endif()
+ 
+ set(byproducts "")
+commit 4edab3d76d72381abeb4ce7089bb02df9ae9fb33
+Author: Alex Beregszaszi <alex@rtfs.hu>
+Date:   Wed Nov 27 23:40:19 2019 +0100
+
+    Update to jsoncpp 1.9.2
+
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index 3e72a8be2..1377041b9 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -37,9 +37,9 @@ endif()
+ ExternalProject_Add(jsoncpp-project
+     PREFIX "${prefix}"
+     DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/deps/downloads"
+-    DOWNLOAD_NAME jsoncpp-1.8.4.tar.gz
+-    URL https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz
+-    URL_HASH SHA256=c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6
++    DOWNLOAD_NAME jsoncpp-1.9.2.tar.gz
++    URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz
++    URL_HASH SHA256=77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0
+     CMAKE_COMMAND ${JSONCPP_CMAKE_COMMAND}
+     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+diff --git a/libdevcore/JSON.cpp b/libdevcore/JSON.cpp
+index 0b08616da..80c116bbe 100644
+--- a/libdevcore/JSON.cpp
++++ b/libdevcore/JSON.cpp
+@@ -32,8 +32,8 @@
+ using namespace std;
+ 
+ static_assert(
+-	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 8) && (JSONCPP_VERSION_PATCH == 4),
+-	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.8.4."
++	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 9) && (JSONCPP_VERSION_PATCH == 2),
++	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.9.2."
+ );
+ 
+ namespace dev
+commit f29780047662b3a67065bf4f81c19e2e2ccb8592
+Author: Daniel Kirchner <daniel@ekpyron.org>
+Date:   Fri Jul 10 19:42:24 2020 +0200
+
+    Upgrade json-cpp to 1.9.3.
+
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index 46d1f2c8e..5db538a6d 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -37,15 +37,16 @@ endif()
+ ExternalProject_Add(jsoncpp-project
+     PREFIX "${prefix}"
+     DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/deps/downloads"
+-    DOWNLOAD_NAME jsoncpp-1.9.2.tar.gz
+-    URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz
+-    URL_HASH SHA256=77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0
++    DOWNLOAD_NAME jsoncpp-1.9.3.tar.gz
++    URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
++    URL_HASH SHA256=8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d
+     CMAKE_COMMAND ${JSONCPP_CMAKE_COMMAND}
+     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                -DCMAKE_INSTALL_LIBDIR=lib
+                # Build static lib but suitable to be included in a shared lib.
+                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
++               -DJSONCPP_WITH_EXAMPLE=OFF
+                -DJSONCPP_WITH_TESTS=OFF
+                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
+                -DCMAKE_CXX_FLAGS=${JSONCPP_CXX_FLAGS}
+diff --git a/libdevcore/JSON.cpp b/libdevcore/JSON.cpp
+index 28b80af98..ddcbe1f65 100644
+--- a/libdevcore/JSON.cpp
++++ b/libdevcore/JSON.cpp
+@@ -28,8 +28,8 @@
+ using namespace std;
+ 
+ static_assert(
+-	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 9) && (JSONCPP_VERSION_PATCH == 2),
+-	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.9.2."
++	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 9) && (JSONCPP_VERSION_PATCH == 3),
++	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.9.3."
+ );
+ 
+ namespace dev
+commit b07e328c1ba08c9ea09fa36ddc757cb6f8086194
+Author: Alexander Arlt <alexander.arlt@arlt-labs.com>
+Date:   Mon Dec 11 15:52:47 2023 +0100
+
+    Add support for apple silicon.
+
+diff --git a/cmake/jsoncpp.cmake b/cmake/jsoncpp.cmake
+index 5db538a6d..4ba3aed7e 100644
+--- a/cmake/jsoncpp.cmake
++++ b/cmake/jsoncpp.cmake
+@@ -34,6 +34,7 @@ if(CMAKE_VERSION VERSION_GREATER 3.1)
+     set(byproducts BUILD_BYPRODUCTS "${JSONCPP_LIBRARY}")
+ endif()
+ 
++string(REPLACE ";" "$<SEMICOLON>" CMAKE_OSX_ARCHITECTURES_ "${CMAKE_OSX_ARCHITECTURES}")
+ ExternalProject_Add(jsoncpp-project
+     PREFIX "${prefix}"
+     DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/deps/downloads"
+@@ -51,6 +52,7 @@ ExternalProject_Add(jsoncpp-project
+                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
+                -DCMAKE_CXX_FLAGS=${JSONCPP_CXX_FLAGS}
+                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
++               -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES_}
+     ${byproducts}
+ )
+ 

--- a/solc_0_4_24/patches/shared-libs-install.patch
+++ b/solc_0_4_24/patches/shared-libs-install.patch
@@ -1,0 +1,64 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0c05208f..8893648e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,6 +48,20 @@ add_subdirectory(libevmasm)
+ add_subdirectory(libsolidity)
+ add_subdirectory(libsolc)
+ 
++
++install(DIRECTORY libdevcore/
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libdevcore
++        FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY libevmasm/
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libevmasm
++        FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY libsolidity/
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libsolidity
++        FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY liblll/
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/liblll
++        FILES_MATCHING PATTERN "*.h")
++
+ if (NOT EMSCRIPTEN)
+ 	add_subdirectory(solc)
+ 	add_subdirectory(liblll)
+diff --git a/libdevcore/CMakeLists.txt b/libdevcore/CMakeLists.txt
+index fa7e3f48..1f9f52b4 100644
+--- a/libdevcore/CMakeLists.txt
++++ b/libdevcore/CMakeLists.txt
+@@ -6,3 +6,4 @@ target_link_libraries(devcore PRIVATE jsoncpp ${Boost_FILESYSTEM_LIBRARIES} ${Bo
+ target_include_directories(devcore PUBLIC "${CMAKE_SOURCE_DIR}")
+ target_include_directories(devcore SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+ add_dependencies(devcore solidity_BuildInfo.h)
++install(TARGETS devcore LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/libevmasm/CMakeLists.txt b/libevmasm/CMakeLists.txt
+index 86192c1b..e7f15e93 100644
+--- a/libevmasm/CMakeLists.txt
++++ b/libevmasm/CMakeLists.txt
+@@ -3,3 +3,4 @@ file(GLOB headers "*.h")
+ 
+ add_library(evmasm ${sources} ${headers})
+ target_link_libraries(evmasm PUBLIC devcore)
++install(TARGETS evmasm LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/liblll/CMakeLists.txt b/liblll/CMakeLists.txt
+index 4cdc073a..b61f03c7 100644
+--- a/liblll/CMakeLists.txt
++++ b/liblll/CMakeLists.txt
+@@ -3,3 +3,4 @@ file(GLOB headers "*.h")
+ 
+ add_library(lll ${sources} ${headers})
+ target_link_libraries(lll PUBLIC evmasm devcore)
++install(TARGETS lll LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/libsolidity/CMakeLists.txt b/libsolidity/CMakeLists.txt
+index 0bdec4b4..e876177e 100644
+--- a/libsolidity/CMakeLists.txt
++++ b/libsolidity/CMakeLists.txt
+@@ -29,6 +29,7 @@ endif()
+ 
+ add_library(solidity ${sources} ${headers})
+ target_link_libraries(solidity PUBLIC evmasm devcore ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
++install(TARGETS solidity LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ if (${Z3_FOUND})
+   target_link_libraries(solidity PUBLIC ${Z3_LIBRARY})


### PR DESCRIPTION
This removes the dependency on the ancient nixpkgs revision and allows building on systems other than linux-amd64.