### PR TITLE
Fix report CSV columns alignment

### DIFF
--- a/cmds/generate_cmds/report.js
+++ b/cmds/generate_cmds/report.js
@@ -99,8 +99,10 @@ exports.handler = async function (argv)
     switch(argv.outputFormat) {
       case 'azimuth-cli':
         csvLine = `${patp},${p},${shipType},${patpParent},`;
+        break;
       case 'bridge':
         csvLine = `${i},${patp},`;
+        break;
     }
     //see if we have a wallet to get the master from
     let masterTicket = '';


### PR DESCRIPTION

Add missing `break` to switch cases.

Fixes a bug where the report csv columns do not line up with the headers.
