### PR TITLE
Update flake.nix dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs_18"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs_24"}:
 
 let
   nodeEnv = import ./node-env.nix {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693985761,
-        "narHash": "sha256-K5b+7j7Tt3+AqbWkcw+wMeqOAWyCD1MH26FPZyWXpdo=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -33,10 +33,26 @@
         "type": "indirect"
       }
     },
+    "nixpkgs2505": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-25.05",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs2505": "nixpkgs2505"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,14 @@
   description = "Command line interface to Azimuth, the Urbit public key infrastructure";
 
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.nixpkgs2505.url = "nixpkgs/nixos-25.05";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, nixpkgs2505, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
+        pkgs2505 = import nixpkgs2505 { inherit system; };
         node2nixOutput = import ./default.nix { inherit pkgs system; };
 
         # The Azimuth smart contracts in package azimuth-solidity need a specific version
@@ -20,6 +22,7 @@
         # https://github.com/NixOS/nixpkgs/tree/5095e9e32eacfcc794227bfe4fd45d5e60285f73/pkgs/development/compilers/solc
         solc_0_4_24 = pkgs.callPackage ./solc_0_4_24 {
           boost = pkgs.boost177;
+          cmake = pkgs2505.cmake;
         };
 
         node2nixOutputOverride = builtins.mapAttrs (name: value: value.override {

--- a/node-env.nix
+++ b/node-env.nix
@@ -3,8 +3,7 @@
 {lib, stdenv, nodejs, python2, pkgs, libtool, runCommand, writeTextFile, writeShellScript}:
 
 let
-  # Workaround to cope with utillinux in Nixpkgs 20.09 and util-linux in Nixpkgs master
-  utillinux = if pkgs ? utillinux then pkgs.utillinux else pkgs.util-linux;
+  utillinux = pkgs.util-linux;
 
   python = if nodejs ? python then nodejs.python else python2;
 


### PR DESCRIPTION
The legacy solc version will not build with CMake 4.x, so I had to pull in an old nixpkgs version to get CMake 3.x